### PR TITLE
Remove test parameters test_array and test_str

### DIFF
--- a/src/pycsh.c
+++ b/src/pycsh.c
@@ -67,16 +67,6 @@
 /* Assertions used when parsing Python arguments, i.e int -> uint32_t */
 static_assert(sizeof(unsigned int) == sizeof(uint32_t));
 
-// We include this parameter when testing the behavior of arrays, as none would exist otherwise.
-uint8_t _test_array[] = {0,1,2,3,4,5,6,7};
-PARAM_DEFINE_STATIC_RAM(1001, test_array_param,          PARAM_TYPE_UINT8,  8, sizeof(uint8_t),  PM_DEBUG, NULL, "", _test_array, "Parameter to use when testing arrays.");
-
-static char _test_str[80];
-PARAM_DEFINE_STATIC_RAM(1002, test_str,          PARAM_TYPE_STRING,  80, 1,  PM_DEBUG, NULL, "", _test_str, "Parameter to use when testing strings");
-
-
-
-
 int pycsh_dfl_verbose = -1;
 
 void * onehz_task(void * param) {


### PR DESCRIPTION
Can we get rid of thes? They clutter the CSH parameter list, when remote operating them