### PR TITLE
Add a "to_bytes" method to Parameter objects

### DIFF
--- a/include/pycsh/utils.h
+++ b/include/pycsh/utils.h
@@ -168,3 +168,14 @@ int pycsh_parse_param_mask(PyObject * mask_in, uint32_t * mask_out);
 
 extern bool csp_router_is_running(void);
 extern void csp_router_set_running(bool is_running);
+
+/**
+ * @brief Convert an arbritrary value to a parameter value, based on parameter type.
+ *
+ * @param type Parameter type, to determine desired output value type from.
+ * @param value_in PyObject* value to parse.
+ * @param dataout Buffer for retrieved value.
+ * @param array_len Needed for array parameters
+ * @return int 0 for success.
+ */
+ int pycsh_param_pyval_to_cval(param_type_e type, PyObject * value_in, void * dataout, size_t array_len);

--- a/pycsh.pyi
+++ b/pycsh.pyi
@@ -630,6 +630,19 @@ class Parameter:
         i.e: `Parameter(...)[...] = ...` == `Parameter(...).value[...] = ...`
         """
 
+    def to_bytes(self, value: int | float | str) -> bytes:
+        """
+        Convert a value of the parameter to bytes, according to the parameter's type.
+        This method uses the param serialization protocol (based on msgpack). 
+
+        :param value: Value to be serialized.
+
+        :raises MemoryError: When the parameter is too big to be serialized.
+        :raises TypeError: When the provided value is of an invalid type for the parameter.
+
+        :returns: The provided value converted to bytes, according to the parameter's type.
+        """
+
 
 class PythonGetSetParameter(Parameter):
     """ ParameterArray created in Python. """

--- a/src/parameter/parameter.c
+++ b/src/parameter/parameter.c
@@ -15,6 +15,7 @@
 #include "structmember.h"
 
 #include <param/param.h>
+#include <param/param_server.h>
 
 #include <pycsh/pycsh.h>
 #include <pycsh/utils.h>
@@ -1118,6 +1119,28 @@ static PyObject * Parameter_list_forget(ParameterObject *self, PyObject *args, P
 }
 
 /* It seems that pedantic does not like how CPython uses flags to communicate function signature. */
+static PyObject * Parameter_to_bytes(ParameterObject *self, PyObject *args, PyObject *kwds) {
+	static char * kwlist[] = {"value", NULL};
+    PyObject * value;
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "O", kwlist, &value)) {
+		return NULL;  // TypeError is thrown
+	}
+
+    uint8_t queuebuffer[PARAM_SERVER_MTU] = {0};
+	param_queue_t queue = { };
+	param_queue_init(&queue, queuebuffer, PARAM_SERVER_MTU, 0, PARAM_QUEUE_TYPE_SET, 2);
+    char temp[queue.buffer_size];
+    if(0 == pycsh_param_pyval_to_cval(((ParameterObject *)self)->param->type, value, temp, ((ParameterObject *)self)->param->array_size)) {
+        if (param_queue_add(&queue, ((ParameterObject *)self)->param, -1, temp) < 0) {
+            PyErr_SetString(PyExc_MemoryError, "Queue full");
+            return NULL;
+        }
+        PyObject *py_queue = Py_BuildValue("y#", queue.buffer, (size_t)queue.used);
+        return py_queue;
+    }
+    return NULL;
+}
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
 static PyMethodDef Parameter_methods[] = {
@@ -1125,6 +1148,7 @@ static PyMethodDef Parameter_methods[] = {
 		"And allows it to be found in `pycsh.list()`")},
     {"list_forget", (PyCFunctionWithKeywords)Parameter_list_forget, METH_VARARGS | METH_KEYWORDS, PyDoc_STR("Remove this parameter from the global parameter list. Hiding it from other CSP nodes on the network. "\
 		"Also removes it from `pycsh.list()`")},
+    {"to_bytes", (PyCFunction)Parameter_to_bytes, METH_VARARGS | METH_KEYWORDS, PyDoc_STR("Return the raw network representation of the parameter, suitable for use in a command queue.")},
     {NULL, NULL, 0, NULL}
 };
 #pragma GCC diagnostic pop

--- a/src/parameter/pythongetsetparameter.c
+++ b/src/parameter/pythongetsetparameter.c
@@ -66,16 +66,7 @@ static PyObject *_pycsh_val_to_pyobject(param_type_e type, const void * value) {
 	return NULL;
 }
 
-/**
- * @brief Convert an arbritrary value to a parameter value, based on parameter type.
- *
- * @param type Parameter type, to determine desired output value type from.
- * @param value_in PyObject* value to parse.
- * @param dataout Buffer for retrieved value.
- * @param array_len Needed for array parameters
- * @return int 0 for success.
- */
-static int _pycsh_param_pyval_to_cval(param_type_e type, PyObject * value_in, void * dataout, size_t array_len) {
+int pycsh_param_pyval_to_cval(param_type_e type, PyObject * value_in, void * dataout, size_t array_len) {
 
     if (value_in == NULL) {
         return -6;
@@ -223,7 +214,7 @@ void Parameter_getter(const vmem_t * vmem, uint64_t addr, void * dataout, uint32
     /* Call the user Python getter */
     PyObject *value AUTO_DECREF = PyObject_CallObject(python_getter, args);
 
-    _pycsh_param_pyval_to_cval(param->type, value, dataout, param->array_size-offset);
+    pycsh_param_pyval_to_cval(param->type, value, dataout, param->array_size-offset);
 
 #if PYCSH_HAVE_APM  // TODO Kevin: This is pretty ugly, but we can't let the error propagate when building for APM, as there is no one but us to catch it.
     if (PyErr_Occurred()) {


### PR DESCRIPTION
- promote "_pycsh_param_pyval_to_cval" to a public API as "pycsh_param_pyval_to_cval"
-  add Parameter_to_bytes function that serializes a parameter to a queue and returns the raw bytes as a Python "bytes" object